### PR TITLE
Require WP CLI only on dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
+    },
+    "require-dev": {
         "wp-cli/wp-cli": "^2.6"
     },
     "bin": [


### PR DESCRIPTION
WP CLI is automatically loaded by WP when available.
It is not expected from this package to brings the whole CLI engine.
That being said, it brings classes and doc for dev, so keeping it for dev env.