### PR TITLE
Added PUBLIC_DIR argument to customise `web` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ By default, MySQL and Mailhog containers will be attached, but you can also use,
 wp sail:install --with=mysql,mailhog,redis
 ```
 
+## PHP Versions
 At this point, you may want to change the version of PHP used in the `docker-compose.yml` file.
 
 ```
@@ -54,6 +55,21 @@ services:
         # ...
 ```
 
+## Alternative Public Path
+If your  WordPress files are in a `web/` directory in your repository then you're good to go - otherwise set the PUBLIC_DIR arg in `docker-compose.yaml`.
+
+```
+version: '3'
+services:
+    wordpress.test:
+        build:
+            context: ./vendor/sterner-stuff/wordpress-sail/runtimes/8.1
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+                PUBLIC_DIR: 'public' <-- path to the directory containing wp-config.php relative to your docker-compose.yaml file
+        # ...
+```
 Finally, build your containers:
 
 ```

--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -4,11 +4,13 @@ LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
 ARG NODE_VERSION=16
+ARG PUBLIC_DIR=web
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
+ENV ABSPATH "/var/www/html/$PUBLIC_DIR"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=wp server --docroot=/var/www/html/web/ --host=0.0.0.0 --port=80
+command=wp server --docroot=%(ENV_ABSPATH)s --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -4,11 +4,13 @@ LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
 ARG NODE_VERSION=16
+ARG PUBLIC_DIR=web
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
+ENV ABSPATH "/var/www/html/$PUBLIC_DIR"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=wp server --docroot=/var/www/html/web/ --host=0.0.0.0 --port=80
+command=wp server --docroot=%(ENV_ABSPATH)s --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -4,11 +4,13 @@ LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
 ARG NODE_VERSION=16
+ARG PUBLIC_DIR=web
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
+ENV ABSPATH "/var/www/html/$PUBLIC_DIR"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=wp server --docroot=/var/www/html/web/ --host=0.0.0.0 --port=80
+command=wp server --docroot=%(ENV_ABSPATH)s --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Allows users to change the public-directory name from `web` to anything they like by (optionally) adding a `PUBLIC_PATH` argument to the docker-compose file.

I've applied the change to 7.4, 8.0 and 8.1 runtimes and it should be backwards compatible without a problem.

If users have published the `Dockerfile` or `supervisord.conf` they'll need to update both if they want to use the argument.

Resolves: https://github.com/sterner-stuff/wordpress-sail/issues/4

Adds these docs to the readme:

## Alternative Public Path
If your  WordPress files are in a `web/` directory in your repository then you're good to go - otherwise set the PUBLIC_DIR arg in `docker-compose.yaml`.

```
version: '3'
services:
    wordpress.test:
        build:
            context: ./vendor/sterner-stuff/wordpress-sail/runtimes/8.1
            dockerfile: Dockerfile
            args:
                WWWGROUP: '${WWWGROUP}'
                PUBLIC_DIR: 'public' <-- path to the directory containing wp-config.php relative to your docker-compose.yaml file
        # ...
```